### PR TITLE
Make the app compatible with Windows Platform

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -309,7 +309,19 @@ async function createWindow(): Promise<void> {
   })
 
   // Enhanced screen capture resistance
-  state.mainWindow.setContentProtection(true)
+
+  if (process.platform === "win32") {
+    setInterval(() => {
+      if (this.mainWindow && !this.mainWindow.isDestroyed()) {
+        // Set the window to be transparent and on top
+        this.mainWindow.setContentProtection(true)
+      }
+    }, 100)
+  }
+  else{
+    state.mainWindow.setContentProtection(true)
+  }
+
   state.mainWindow.setHiddenInMissionControl(true)
   state.mainWindow.setVisibleOnAllWorkspaces(true, {
     visibleOnFullScreen: true


### PR DESCRIPTION
This essentially fixes and add support for Windows OS

- The problem was re-render was I guess causing the mainWindow to have it set to false.

- The setInterval time may seem aggresive but it makes sense so it doesn't show up on screen.

- Really hacky way but I think if it works, it works, could maybe add TODO, to do it gracefully in the future.