### PR TITLE
Change key to use cmd + shift

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ Note: The application is **NOT** invisible to:
 
 The application uses unidentifiable global keyboard shortcuts that won't be detected by browsers or other applications:
 
-- Toggle Window Visibility: [Control or Cmd + b]
-- Move Window: [Control or Cmd + arrows]
-- Take Screenshot: [Control or Cmd + H]
-- Process Screenshots: [Control or Cmd + Enter]
-- Reset View: [Control or Cmd + R]
-- Quit: [Control or Cmd + Q]
+- Toggle Window Visibility: [Control or Cmd + Shift + b]
+- Move Window: [Control or Cmd + Shift + arrows]
+- Take Screenshot: [Control or Cmd + Shift + H]
+- Process Screenshots: [Control or Cmd + Shift + Enter]
+- Reset View: [Control or Cmd + Shift + R]
+- Quit: [Control or Cmd + Shift + Q]
 
 ## Usage
 
@@ -51,7 +51,7 @@ The application uses unidentifiable global keyboard shortcuts that won't be dete
 
 2. **Capturing Problem**
 
-   - Use global shortcut [Control or Cmd + H] to take screenshots
+   - Use global shortcut [Control or Cmd + Shift + H] to take screenshots
    - Screenshots are automatically added to the queue of up to 5.
 
 3. **Processing**
@@ -74,7 +74,7 @@ The application uses unidentifiable global keyboard shortcuts that won't be dete
    - Move window freely using global shortcut
    - Toggle visibility as needed
    - Window remains invisible to specified applications
-   - Reset view using Command + R
+   - Reset view using Command + Shift + R
 
 ## Prerequisites
 

--- a/electron/shortcuts.ts
+++ b/electron/shortcuts.ts
@@ -9,7 +9,7 @@ export class ShortcutsHelper {
   }
 
   public registerGlobalShortcuts(): void {
-    globalShortcut.register("CommandOrControl+H", async () => {
+    globalShortcut.register("CommandOrControl+Shift+H", async () => {
       const mainWindow = this.deps.getMainWindow()
       if (mainWindow) {
         console.log("Taking screenshot...")
@@ -26,13 +26,13 @@ export class ShortcutsHelper {
       }
     })
 
-    globalShortcut.register("CommandOrControl+Enter", async () => {
+    globalShortcut.register("CommandOrControl+Shift+Enter", async () => {
       await this.deps.processingHelper?.processScreenshots()
     })
 
-    globalShortcut.register("CommandOrControl+R", () => {
+    globalShortcut.register("CommandOrControl+Shift+R", () => {
       console.log(
-        "Command + R pressed. Canceling requests and resetting queues..."
+        "Command + Shift + R pressed. Canceling requests and resetting queues..."
       )
 
       // Cancel ongoing API requests
@@ -55,27 +55,27 @@ export class ShortcutsHelper {
     })
 
     // New shortcuts for moving the window
-    globalShortcut.register("CommandOrControl+Left", () => {
-      console.log("Command/Ctrl + Left pressed. Moving window left.")
+    globalShortcut.register("CommandOrControl+Shift+Left", () => {
+      console.log("Command/Ctrl + Shift + Left pressed. Moving window left.")
       this.deps.moveWindowLeft()
     })
 
-    globalShortcut.register("CommandOrControl+Right", () => {
-      console.log("Command/Ctrl + Right pressed. Moving window right.")
+    globalShortcut.register("CommandOrControl+Shift+Right", () => {
+      console.log("Command/Ctrl + Shift + Right pressed. Moving window right.")
       this.deps.moveWindowRight()
     })
 
-    globalShortcut.register("CommandOrControl+Down", () => {
-      console.log("Command/Ctrl + down pressed. Moving window down.")
+    globalShortcut.register("CommandOrControl+Shift+Down", () => {
+      console.log("Command/Ctrl + Shift + down pressed. Moving window down.")
       this.deps.moveWindowDown()
     })
 
-    globalShortcut.register("CommandOrControl+Up", () => {
-      console.log("Command/Ctrl + Up pressed. Moving window Up.")
+    globalShortcut.register("CommandOrControl+Shift+Up", () => {
+      console.log("Command/Ctrl + Shift + Up pressed. Moving window Up.")
       this.deps.moveWindowUp()
     })
 
-    globalShortcut.register("CommandOrControl+B", () => {
+    globalShortcut.register("CommandOrControl+Shift+B", () => {
       this.deps.toggleMainWindow()
     })
 

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -8,7 +8,7 @@ const getPlatform = () => {
 }
 
 // Platform-specific command key symbol
-export const COMMAND_KEY = getPlatform() === 'darwin' ? '⌘' : 'Ctrl'
+export const COMMAND_KEY = getPlatform() === 'darwin' ? '⌘ + Shift' : 'Ctrl + Shift'
 
 // Helper to check if we're on Windows
 export const isWindows = getPlatform() === 'win32'


### PR DESCRIPTION
Feature suggestion to prevent `cmd` + arrows key / `cmd` + `R` not work in coding pad 